### PR TITLE
Release `PhotoImage` objects when cell widgets are destroyed.

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -58,5 +58,4 @@ class Application(tk.Frame):
     def restart(self, event=None):
         for child in self.parent.winfo_children():
             child.destroy()
-        gc.collect()
         self.__init__(self.parent, self.settings)

--- a/app/cell.py
+++ b/app/cell.py
@@ -14,13 +14,22 @@ class Cell(tk.Button):
         self.bomb = False
         self.folder = os.path.dirname(__file__)
         self.state = "closed"
-        self.closed_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/closed.png")))
-        self.configure(image=self.closed_image)
-        self.last_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/boom.png")))
-        self.bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/bomb.png")))
-        self.not_bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/wrong.png")))
-        self.marked_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/marked.png")))
-        self.opened_image = None
+        self._closed_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/closed.png")))
+        self.configure(image=self._closed_image)
+        self._last_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/boom.png")))
+        self._bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/bomb.png")))
+        self._not_bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/wrong.png")))
+        self._marked_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/marked.png")))
+        self._opened_image = None
+        self.bind("<Destroy>", self._on_destroy)
+
+    # Image control
+    def _get_opened_image(self):
+        return self._opened_image
+    def _set_opened_image(self, opened_image):
+        del self._opened_image
+        self._opened_image = opened_image
+    opened_image = property(_get_opened_image, _set_opened_image)
 
     # Getters
     def is_bomb(self):
@@ -54,11 +63,11 @@ class Cell(tk.Button):
 
     def close(self):
         self.state = "closed"
-        self.configure(image=self.closed_image, state="normal")
+        self.configure(image=self._closed_image, state="normal")
 
     def open(self):
         if not self.is_marked():
-            self.configure(image=self.opened_image, relief="sunken")
+            self.configure(image=self._opened_image, relief="sunken")
             self.unbind("<B1>")
             self.state = "disabled"
             if self.is_bomb():
@@ -72,7 +81,7 @@ class Cell(tk.Button):
             counter = self.field.number_of_bombs
             if self.is_closed():
                 self.state = "marked"
-                self.configure(image=self.marked_image)
+                self.configure(image=self._marked_image)
                 counter.set(counter.get()-1)
             elif self.is_marked():
                 self.close()
@@ -101,7 +110,7 @@ class Cell(tk.Button):
                 cell.configure(relief="raised")
 
     def blow_up(self):
-        self.configure(image=self.last_image)
+        self.configure(image=self._last_image)
         self.field.place_of_death = self.column + self.row
 
     # Function recursively checks if the cell has no bombs around and opens them
@@ -131,3 +140,12 @@ class Cell(tk.Button):
             button = self.field.cells[n]
             if button.is_closed():
                 button.configure(relief="raised")
+
+    # Lifecycle handlers
+    def _on_destroy(self, *args):
+        del(self._closed_image)
+        del(self._last_image)
+        del(self._bomb_image)
+        del(self._not_bomb_image)
+        del(self._marked_image)
+        del(self._opened_image)


### PR DESCRIPTION
Previously these objects were taken care of by the garbage collector, which was called directly in `Application.restart`. Now `Cell` widgets free their resources themselves when they are destroyed and the manual `gc.collect()` call is no longer needed.

btw, Here is what happens if `gc.collect()` is commented out (before the changes in this PR):

Before:
![minesweeper before](https://user-images.githubusercontent.com/52021/38637989-75f9e71a-3dd5-11e8-90a3-ea8b9bda58f7.png)

After `Game > New > Yes`:
![minesweeper after](https://user-images.githubusercontent.com/52021/38637987-75d727c0-3dd5-11e8-82a0-9addd8c9a00f.png)