### PR TITLE
Boost init

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -51,12 +51,12 @@ class Application(tk.Frame):
         self.field.show_the_bombs()
         SimpleDialog(self, "win")
 
-    def exit(self, event=None):
+    def exit(self):
         for child in self.parent.winfo_children():
             child.destroy()
         self.parent.quit()
 
-    def restart(self, event=None):
+    def restart(self):
         for child in self.parent.winfo_children():
             child.destroy()
         self.__init__(self.parent, self.settings)

--- a/app/cell.py
+++ b/app/cell.py
@@ -20,17 +20,8 @@ class Cell(tk.Button):
         self._bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/bomb.png")))
         self._not_bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/wrong.png")))
         self._marked_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/marked.png")))
-        self._opened_image = None
+        self.opened_image = property(self.get_opened_image, self.set_opened_image)
         self.bind("<Destroy>", self._on_destroy)
-
-    # Image control
-    def _get_opened_image(self):
-        return self._opened_image
-
-    def _set_opened_image(self, opened_image):
-        del self._opened_image
-        self._opened_image = opened_image
-    opened_image = property(_get_opened_image, _set_opened_image)
 
     # Getters
     def is_bomb(self):
@@ -44,6 +35,13 @@ class Cell(tk.Button):
 
     def is_marked(self):
         return self.state == "marked"
+
+    def get_opened_image(self):
+        return self.opened_image
+
+    # Setters
+    def set_opened_image(self, opened_image):
+        self.opened_image = opened_image
 
     # State changers
     def activate(self):
@@ -68,7 +66,7 @@ class Cell(tk.Button):
 
     def open(self):
         if not self.is_marked():
-            self.configure(image=self._opened_image, relief="sunken")
+            self.configure(image=self.get_opened_image(), relief="sunken")
             self.unbind("<B1>")
             self.state = "disabled"
             if self.is_bomb():
@@ -150,9 +148,9 @@ class Cell(tk.Button):
 
     # Lifecycle handlers
     def _on_destroy(self, *args):
-        del(self._closed_image)
-        del(self._last_image)
-        del(self._bomb_image)
-        del(self._not_bomb_image)
-        del(self._marked_image)
-        del(self._opened_image)
+        del self._closed_image
+        del self._last_image
+        del self._bomb_image
+        del self._not_bomb_image
+        del self._marked_image
+        del self.opened_image

--- a/app/cell.py
+++ b/app/cell.py
@@ -13,7 +13,7 @@ class Cell(tk.Button):
         self.bomb = False
         self.state = "closed"
         self.closed_image = background
-        self.configure(image=self.closed_image)
+        self.configure(image=self.get_closed_image())
         self.last_image = property(self.get_last_image, self.set_last_image)
         self.bomb_image = property(self.get_bomb_image, self.set_bomb_image)
         self.marked_image = mark
@@ -75,11 +75,11 @@ class Cell(tk.Button):
         self.bomb = True
         self.set_bomb_image(bomb_image)
         self.set_opened_image(bomb_image)
-        self.last_image = last_image
+        self.set_last_image(last_image)
 
     def close(self):
         self.state = "closed"
-        self.configure(image=self.closed_image, state="normal")
+        self.configure(image=self.get_closed_image(), state="normal")
 
     def open(self):
         if not self.is_marked():
@@ -108,7 +108,7 @@ class Cell(tk.Button):
     def show(self, place_of_death):
         if ((self.is_bomb() and not self.is_marked() and not place_of_death) or
                 (not self.is_bomb() and self.is_marked())):
-            self.configure(image=self.bomb_image)
+            self.configure(image=self.get_bomb_image())
 
     # Other actions
     def automated_opening(self, event=None):
@@ -131,7 +131,7 @@ class Cell(tk.Button):
                 cell.configure(relief="raised")
 
     def blow_up(self):
-        self.configure(image=self.last_image)
+        self.configure(image=self.get_last_image())
         self.field.place_of_death = self.column + self.row
 
     # Function recursively checks if the cell has no bombs around and opens them

--- a/app/field.py
+++ b/app/field.py
@@ -31,6 +31,7 @@ class Field(tk.Frame):
             cell = self.get_random_cell()
             if not cell.is_bomb():
                 cell.bomb = True
+                cell.set_opened_image(tk.PhotoImage(file=(os.path.join(cell.folder, "../img/bomb.png"))))
                 counter += 1
         # Filling non-bomb cells with numbers of nearby bombs
         for name in self.cells:
@@ -42,10 +43,11 @@ class Field(tk.Frame):
                     if self.cells[n].is_bomb():
                         counter += 1
                 if counter == 0:
-                    cell.opened_image = tk.PhotoImage(file=(os.path.join(cell.folder, "../img/empty.png")))
+                    cell.set_opened_image(tk.PhotoImage(file=(os.path.join(cell.folder, "../img/empty.png"))))
                 else:
                     cell.nearby_bombs = counter
-                    cell.opened_image = tk.PhotoImage(file=(os.path.join(cell.folder, "../img/{}.png".format(counter))))
+                    cell.set_opened_image(tk.PhotoImage(file=(os.path.join(cell.folder,
+                                                                           "../img/{}.png".format(counter)))))
         # Placing cells on the field
         for name in self.cells:
             cell = self.cells[name]

--- a/app/field.py
+++ b/app/field.py
@@ -17,6 +17,23 @@ class Field(tk.Frame):
         self.number_of_bombs.set(settings.number_of_bombs)
         self.bomb_counter = tk.Label(self, textvariable=self.number_of_bombs, font="courier 15 bold", fg="red")
         self.bomb_counter.grid(column=0, columnspan=len(self.columns), row=0)
+        self.folder = os.path.dirname(__file__)
+        self.cell_images = {
+            "closed": tk.PhotoImage(file=(os.path.join(self.folder, "../img/closed.png"))),
+            "last": tk.PhotoImage(file=(os.path.join(self.folder, "../img/boom.png"))),
+            "bomb": tk.PhotoImage(file=(os.path.join(self.folder, "../img/bomb.png"))),
+            "not_bomb": tk.PhotoImage(file=(os.path.join(self.folder, "../img/wrong.png"))),
+            "marked": tk.PhotoImage(file=(os.path.join(self.folder, "../img/marked.png"))),
+            "0": tk.PhotoImage(file=(os.path.join(self.folder, "../img/empty.png"))),
+            "1": tk.PhotoImage(file=(os.path.join(self.folder, "../img/1.png"))),
+            "2": tk.PhotoImage(file=(os.path.join(self.folder, "../img/2.png"))),
+            "3": tk.PhotoImage(file=(os.path.join(self.folder, "../img/3.png"))),
+            "4": tk.PhotoImage(file=(os.path.join(self.folder, "../img/4.png"))),
+            "5": tk.PhotoImage(file=(os.path.join(self.folder, "../img/5.png"))),
+            "6": tk.PhotoImage(file=(os.path.join(self.folder, "../img/6.png"))),
+            "7": tk.PhotoImage(file=(os.path.join(self.folder, "../img/7.png"))),
+            "8": tk.PhotoImage(file=(os.path.join(self.folder, "../img/8.png")))
+        }
         self.grid()
         self.create_field()
 
@@ -24,14 +41,13 @@ class Field(tk.Frame):
     def create_field(self):
         for i in range(self.rows):
             for j in self.columns:
-                self.cells[j+str(i)] = Cell(self, i, j)
+                self.cells[j+str(i)] = Cell(self, i, j, self.cell_images["closed"], self.cell_images["marked"])
         counter = 0
         # Placing bombs
         while counter < self.number_of_bombs.get():
             cell = self.get_random_cell()
             if not cell.is_bomb():
-                cell.bomb = True
-                cell.set_opened_image(tk.PhotoImage(file=(os.path.join(cell.folder, "../img/bomb.png"))))
+                cell.add_bomb(self.cell_images["bomb"], self.cell_images["last"])
                 counter += 1
         # Filling non-bomb cells with numbers of nearby bombs
         for name in self.cells:
@@ -42,12 +58,9 @@ class Field(tk.Frame):
                 for n in neighbours:
                     if self.cells[n].is_bomb():
                         counter += 1
-                if counter == 0:
-                    cell.set_opened_image(tk.PhotoImage(file=(os.path.join(cell.folder, "../img/empty.png"))))
-                else:
-                    cell.nearby_bombs = counter
-                    cell.set_opened_image(tk.PhotoImage(file=(os.path.join(cell.folder,
-                                                                           "../img/{}.png".format(counter)))))
+                cell.nearby_bombs = counter
+                cell.set_opened_image(self.cell_images["{}".format(counter)])
+                cell.set_bomb_image(self.cell_images["not_bomb"])
         # Placing cells on the field
         for name in self.cells:
             cell = self.cells[name]

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,7 +7,7 @@ from .settings_dialog import SettingsDialog
 class Settings(object):
 
     def __init__(self, app):
-        self.version = "2.0.0rc2"
+        self.version = "2.0.0"
         self.app = app
         self.rows = 10
         self.temp_rows = tk.IntVar()


### PR DESCRIPTION
Images are now loaded one time for the game field instead of loading them for the every cell. It reduced memory consumption and decreased the loading/restarting time. It also allowed to remove destructor for cell class preventing memory leak.