### PR TITLE
Load images only once

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -7,20 +7,21 @@ from .simple_dialog import SimpleDialog
 
 class Application(tk.Frame):
 
-    def __init__(self, parent, settings=None):
+    def __init__(self, parent):
         super().__init__()
-        if settings is None:
-            self.settings = Settings(self)
-        else:
-            self.settings = settings
+        self.settings = Settings(self)
         self.images = ImageKeeper()
-        self.language = self.settings.language
+        self.language = None
         self.parent = parent
         self.parent.resizable(0, 0)
         self.parent.protocol("WM_DELETE_WINDOW", self.ensure_exit)
+        self.field = None
+        self.create_window()
+
+    def create_window(self):
+        self.language = self.settings.language
         self.parent.config(menu=self.create_menu(self))
         self.parent.title(self.language["title"])
-        self.grid()
         self.field = Field(self, self.settings, self.images)
 
     # Main menu
@@ -53,12 +54,13 @@ class Application(tk.Frame):
         self.field.show_the_bombs()
         SimpleDialog(self, "win")
 
-    def exit(self, event=None):
+    def exit(self):
         for child in self.parent.winfo_children():
             child.destroy()
         self.parent.quit()
 
-    def restart(self, event=None):
+    def restart(self):
         for child in self.parent.winfo_children():
-            child.destroy()
-        self.__init__(self.parent, self.settings)
+            if child != self:
+                child.destroy()
+        self.create_window()

--- a/app/application.py
+++ b/app/application.py
@@ -1,7 +1,8 @@
 import tkinter as tk
-from .simple_dialog import SimpleDialog
 from .field import Field
+from .image_keeper import ImageKeeper
 from .settings import Settings
+from .simple_dialog import SimpleDialog
 
 
 class Application(tk.Frame):
@@ -12,6 +13,7 @@ class Application(tk.Frame):
             self.settings = Settings(self)
         else:
             self.settings = settings
+        self.images = ImageKeeper()
         self.language = self.settings.language
         self.parent = parent
         self.parent.resizable(0, 0)
@@ -19,7 +21,7 @@ class Application(tk.Frame):
         self.parent.config(menu=self.create_menu(self))
         self.parent.title(self.language["title"])
         self.grid()
-        self.field = Field(self, self.settings)
+        self.field = Field(self, self.settings, self.images)
 
     # Main menu
     def create_menu(self, master):

--- a/app/application.py
+++ b/app/application.py
@@ -63,4 +63,7 @@ class Application(tk.Frame):
         for child in self.parent.winfo_children():
             if child != self:
                 child.destroy()
+        for cell in self.field.cells.keys():
+            self.field.cells[cell] = None
+        self.field = None
         self.create_window()

--- a/app/cell.py
+++ b/app/cell.py
@@ -20,7 +20,6 @@ class Cell(tk.Button):
         self._not_bomb_image = self.images.wrong
         self._marked_image = self.images.marked
         self._opened_image = None
-        self.bind("<Destroy>", self._on_destroy)
 
     # Image control
     def _get_opened_image(self):

--- a/app/cell.py
+++ b/app/cell.py
@@ -1,10 +1,9 @@
-import os
 import tkinter as tk
 
 
 class Cell(tk.Button):
 
-    def __init__(self, master, row, column):
+    def __init__(self, master, row, column, images):
         super().__init__(master=master)
         self.field = master
         self.app = master.parent
@@ -12,14 +11,14 @@ class Cell(tk.Button):
         self.column = str(column)
         self.nearby_bombs = None
         self.bomb = False
-        self.folder = os.path.dirname(__file__)
         self.state = "closed"
-        self._closed_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/closed.png")))
+        self.images = images
+        self._closed_image = self.images.closed
         self.configure(image=self._closed_image)
-        self._last_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/boom.png")))
-        self._bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/bomb.png")))
-        self._not_bomb_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/wrong.png")))
-        self._marked_image = tk.PhotoImage(file=(os.path.join(self.folder, "../img/marked.png")))
+        self._last_image = self.images.boom
+        self._bomb_image = self.images.bomb
+        self._not_bomb_image = self.images.wrong
+        self._marked_image = self.images.marked
         self._opened_image = None
         self.bind("<Destroy>", self._on_destroy)
 
@@ -31,6 +30,10 @@ class Cell(tk.Button):
         del self._opened_image
         self._opened_image = opened_image
     opened_image = property(_get_opened_image, _set_opened_image)
+
+    def set_closed_image(self, counter):
+        self.nearby_bombs = counter if counter != 0 else None
+        self.opened_image = self.images.opened["{}".format(counter)]
 
     # Getters
     def is_bomb(self):

--- a/app/cell.py
+++ b/app/cell.py
@@ -109,6 +109,10 @@ class Cell(tk.Button):
             if amount_of_opened_nearby_bombs == self.nearby_bombs:
                 for n in neighbours:
                     cell = self.field.cells[n]
+                    # When player was wrong and previous cell blew up,
+                    # cells are deleted and following opening is not needed
+                    if not cell:
+                        return
                     if cell.is_closed():
                         cell.open()
         elif self.is_closed():

--- a/app/cell.py
+++ b/app/cell.py
@@ -150,12 +150,3 @@ class Cell(tk.Button):
             button = self.field.cells[n]
             if button.is_closed():
                 button.configure(relief="raised")
-
-    # Lifecycle handlers
-    def _on_destroy(self, *args):
-        del(self._closed_image)
-        del(self._last_image)
-        del(self._bomb_image)
-        del(self._not_bomb_image)
-        del(self._marked_image)
-        del(self._opened_image)

--- a/app/field.py
+++ b/app/field.py
@@ -1,4 +1,3 @@
-import os
 import random
 import tkinter as tk
 from .cell import Cell
@@ -6,9 +5,10 @@ from .cell import Cell
 
 class Field(tk.Frame):
 
-    def __init__(self, master, settings):
+    def __init__(self, master, settings, images):
         super().__init__()
         self.parent = master
+        self.img = images
         self.place_of_death = None
         self.cells = {}
         self.columns = settings.available_columns[:settings.columns]
@@ -24,7 +24,7 @@ class Field(tk.Frame):
     def create_field(self):
         for i in range(self.rows):
             for j in self.columns:
-                self.cells[j+str(i)] = Cell(self, i, j)
+                self.cells[j+str(i)] = Cell(self, i, j, self.img)
         counter = 0
         # Placing bombs
         while counter < self.number_of_bombs.get():
@@ -41,11 +41,7 @@ class Field(tk.Frame):
                 for n in neighbours:
                     if self.cells[n].is_bomb():
                         counter += 1
-                if counter == 0:
-                    cell.opened_image = tk.PhotoImage(file=(os.path.join(cell.folder, "../img/empty.png")))
-                else:
-                    cell.nearby_bombs = counter
-                    cell.opened_image = tk.PhotoImage(file=(os.path.join(cell.folder, "../img/{}.png".format(counter))))
+                cell.set_closed_image(counter)
         # Placing cells on the field
         for name in self.cells:
             cell = self.cells[name]

--- a/app/image_keeper.py
+++ b/app/image_keeper.py
@@ -1,0 +1,24 @@
+import os
+import tkinter as tk
+
+
+class ImageKeeper:
+
+    def __init__(self):
+        self.folder = os.path.dirname(__file__)
+        self.closed = tk.PhotoImage(file=(os.path.join(self.folder, "../img/closed.png")))
+        self.boom = tk.PhotoImage(file=(os.path.join(self.folder, "../img/boom.png")))
+        self.bomb = tk.PhotoImage(file=(os.path.join(self.folder, "../img/bomb.png")))
+        self.wrong = tk.PhotoImage(file=(os.path.join(self.folder, "../img/wrong.png")))
+        self.marked = tk.PhotoImage(file=(os.path.join(self.folder, "../img/marked.png")))
+        self.opened = {
+            "0": tk.PhotoImage(file=(os.path.join(self.folder, "../img/empty.png"))),
+            "1": tk.PhotoImage(file=(os.path.join(self.folder, "../img/1.png"))),
+            "2": tk.PhotoImage(file=(os.path.join(self.folder, "../img/2.png"))),
+            "3": tk.PhotoImage(file=(os.path.join(self.folder, "../img/3.png"))),
+            "4": tk.PhotoImage(file=(os.path.join(self.folder, "../img/4.png"))),
+            "5": tk.PhotoImage(file=(os.path.join(self.folder, "../img/5.png"))),
+            "6": tk.PhotoImage(file=(os.path.join(self.folder, "../img/6.png"))),
+            "7": tk.PhotoImage(file=(os.path.join(self.folder, "../img/7.png"))),
+            "8": tk.PhotoImage(file=(os.path.join(self.folder, "../img/8.png")))
+        }

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,7 +7,7 @@ from .settings_dialog import SettingsDialog
 class Settings(object):
 
     def __init__(self, app):
-        self.version = "2.0.0rc2"
+        self.version = "2.0.0"
         self.app = app
         self.rows = 10
         self.temp_rows = tk.IntVar()

--- a/app/settings.py
+++ b/app/settings.py
@@ -77,7 +77,7 @@ class Settings(object):
         self.max_width = 30
         self.min_no_of_bombs = 3
         self.max_no_of_bombs = tk.IntVar()
-        self.max_no_of_bombs.set(math.floor(self.temp_rows.get() * self.temp_columns.get() * 0.75))
+        self.max_no_of_bombs.set(math.floor(self.temp_rows.get() * self.temp_columns.get() * 0.5))
 
     def apply_temp_settings(self, listbox_value):
         self.rows = self.temp_rows.get()


### PR DESCRIPTION
Images are now stored in the separate object. Earlier Application was recreated on every restart, and other objects didn't destroyed because cells were linked to the field and the field was linked to the cells, so their reference counter was never equal 0. Now, Application created only once and keep link to ImageKeeper object. On restart field and cells are explicitly replaced with None, that effectively reduce reference counter. Memory usage almost doesn't increase and the program works faster. 